### PR TITLE
Increasing the verbosity of error messages to enable better troubleshooting

### DIFF
--- a/system/Exceptions/BaseExceptionClass.php
+++ b/system/Exceptions/BaseExceptionClass.php
@@ -102,7 +102,7 @@ class BaseExceptionClass extends \Exception implements BaseExceptionInterface  {
 	*/
 	public function getErrorMessage(){
 
-		$backTrace = $this->getTraceAsString(); $appendPrevious = substr($backTrace, 2, strpos($backTrace, "#1") - 2);
+		$backTrace = $this->getTraceAsString(); $appendPrevious = substr($backTrace, 2, strpos($backTrace, "#2") - 2);
 
 		//define and return the error message to show
 		$this->errorMessageContent = '<b>' . $this->getMessage() . ' ' . $this->getFile() . '(' . $this->getLine() . ')</b> As seen from ' . $appendPrevious;

--- a/system/Exceptions/BaseExceptionClass.php
+++ b/system/Exceptions/BaseExceptionClass.php
@@ -102,7 +102,7 @@ class BaseExceptionClass extends \Exception implements BaseExceptionInterface  {
 	*/
 	public function getErrorMessage(){
 
-		$backTrace = $this->getTraceAsString(); $appendPrevious = substr($backTrace, 2, strpos($backTrace, "#2") - 2);
+		$backTrace = $this->getTraceAsString(); $appendPrevious = $backTrace;// substr($backTrace, 2, strpos($backTrace, "#2") - 2);
 
 		//define and return the error message to show
 		$this->errorMessageContent = '<b>' . $this->getMessage() . ' ' . $this->getFile() . '(' . $this->getLine() . ')</b> As seen from ' . $appendPrevious;

--- a/system/Exceptions/Debug/BaseShutdown.php
+++ b/system/Exceptions/Debug/BaseShutdown.php
@@ -136,7 +136,7 @@ function handler( $errNo, $errMsg, $errFile, $errLine ) {
     $rootPath = dirname(dirname(dirname((dirname(__FILE__)))));
 
     $exceptionObject = new Exception;$backTrace = $exceptionObject->getTraceAsString();
-    $appendPrevious = substr($backTrace, 2, strpos($backTrace, "#1") - 2);
+    $appendPrevious = substr($backTrace, 2, strpos($backTrace, "#2") - 2);
 
     //compose an error message to display
     $showErrorMessage = "<b>$errorType: $errMsg in $errFile on line($errLine)</b> As seen from $appendPrevious";

--- a/system/Exceptions/Debug/BaseShutdown.php
+++ b/system/Exceptions/Debug/BaseShutdown.php
@@ -136,7 +136,7 @@ function handler( $errNo, $errMsg, $errFile, $errLine ) {
     $rootPath = dirname(dirname(dirname((dirname(__FILE__)))));
 
     $exceptionObject = new Exception;$backTrace = $exceptionObject->getTraceAsString();
-    $appendPrevious = substr($backTrace, 2, strpos($backTrace, "#2") - 2);
+    $appendPrevious = $backTrace;//substr($backTrace, 2, strpos($backTrace, "#4") - 2);
 
     //compose an error message to display
     $showErrorMessage = "<b>$errorType: $errMsg in $errFile on line($errLine)</b> As seen from $appendPrevious";

--- a/system/Exceptions/ErrorPageHtml.php
+++ b/system/Exceptions/ErrorPageHtml.php
@@ -10,7 +10,57 @@
     <link href='http://fonts.googleapis.com/css?family=Raleway:400,700,600' rel='stylesheet' type='text/css'>
 	
 	<title><?php $title = (isset($title)) ? $title: 'Gliver @Error!'; echo $title; ?> </title>
+
 	<style type="text/css">
+		@font-face {
+		  font-family: 'Lato';
+		  font-style: normal;
+		  font-weight: 300;
+		  src: local('Lato Light'), local('Lato-Light'), url(http://fonts.gstatic.com/s/lato/v11/KT3KS9Aol4WfR6Vas8kNcg.woff) format('woff');
+		}
+		@font-face {
+		  font-family: 'Lato';
+		  font-style: normal;
+		  font-weight: 400;
+		  src: local('Lato Regular'), local('Lato-Regular'), url(http://fonts.gstatic.com/s/lato/v11/9k-RPmcnxYEPm8CNFsH2gg.woff) format('woff');
+		}
+		@font-face {
+		  font-family: 'Lato';
+		  font-style: normal;
+		  font-weight: 700;
+		  src: local('Lato Bold'), local('Lato-Bold'), url(http://fonts.gstatic.com/s/lato/v11/wkfQbvfT_02e2IWO3yYueQ.woff) format('woff');
+		}
+		@font-face {
+		  font-family: 'Lato';
+		  font-style: italic;
+		  font-weight: 300;
+		  src: local('Lato Light Italic'), local('Lato-LightItalic'), url(http://fonts.gstatic.com/s/lato/v11/2HG_tEPiQ4Z6795cGfdivD8E0i7KZn-EPnyo3HZu7kw.woff) format('woff');
+		}
+		@font-face {
+		  font-family: 'Lato';
+		  font-style: italic;
+		  font-weight: 400;
+		  src: local('Lato Italic'), local('Lato-Italic'), url(http://fonts.gstatic.com/s/lato/v11/oUan5VrEkpzIazlUe5ieaA.woff) format('woff');
+		}
+		@font-face {
+		  font-family: 'Lato';
+		  font-style: italic;
+		  font-weight: 700;
+		  src: local('Lato Bold Italic'), local('Lato-BoldItalic'), url(http://fonts.gstatic.com/s/lato/v11/HkF_qI1x_noxlxhrhMQYED8E0i7KZn-EPnyo3HZu7kw.woff) format('woff');
+		}
+	</style>
+	<style type="text/css">
+
+		body,
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+		    font-family: "Lato","Helvetica Neue",Helvetica,Arial,sans-serif;
+		    /*font-weight: 700;*/
+		}
 	    body {
 	        margin:0;
 	        font-family:'Lato', sans-serif;

--- a/system/Helpers/Upload/Upload.php
+++ b/system/Helpers/Upload/Upload.php
@@ -96,6 +96,37 @@ class Upload {
 	}
 
 	/**
+	*This method sets the file type of the uploaded file
+	*
+	*@param null
+	*@return \Object This static class instance
+	*/
+	protected static function setFiletype()
+	{
+		//call the method to set the file type
+		self::$uploadClassInstance->setFiletype();
+
+		return new static;
+
+	}
+
+	/**
+	*This method sets a unique target file name
+	*
+	*@param null
+	*@return \Object This static class instance
+	*/
+	protected static function setTargetfilename()
+	{
+		//call the method to set the target file
+		self::$uploadClassInstance->setTargetfilename();
+
+		return new static;
+
+	}
+
+
+	/**
 	*This method sets the target file name
 	*
 	*@param null
@@ -111,15 +142,14 @@ class Upload {
 	}
 
 	/**
-	*This method sets the file type of the uploaded file
-	*
-	*@param null
+	*This method checks if a valid file type was uploaded
+	*@param string $file_type The name of the file type to check
 	*@return \Object This static class instance
 	*/
-	protected static function setFiletype()
+	protected static function checkFiletype($file_type)
 	{
 		//call the method to check for the file type
-		self::$uploadClassInstance->setFiletype();
+		self::$uploadClassInstance->checkFiletype($file_type);
 
 		return new static;
 
@@ -155,8 +185,10 @@ class Upload {
 			->setUploadpath($target_dir)
 			->setFilename($file_name)
 			->setTargetdir()
-			->setTargetfile()
 			->setFiletype()
+			->setTargetfilename()
+			->setTargetfile()		
+			->checkFiletype($file_type)
 			->setFilesize();
 
 		//call method to upload file

--- a/system/Helpers/Upload/UploadClass.php
+++ b/system/Helpers/Upload/UploadClass.php
@@ -26,6 +26,11 @@ class UploadClass {
 	private $file_name;
 
 	/**
+	*@var string The target file name
+	*/
+	private $target_file_name;
+
+	/**
 	*@var string The target directory for the file upload
 	*/
 	private $target_dir;
@@ -105,24 +110,6 @@ class UploadClass {
 	}
 
 	/**
-	*This method sets the target file name
-	*
-	*@param null
-	*@return \Object $this instance
-	*/
-	public function setTargetfile()
-	{
-		//set the upload_path_relative
-		$this->upload_path_relative = $this->upload_path . basename($_FILES[$this->file_name]["name"]);
-
-		//set the full target file path
-		$this->target_file = $this->target_dir . basename($_FILES[$this->file_name]["name"]);
-
-		return $this;
-
-	}
-
-	/**
 	*This method sets the file type of the uploaded file
 	*
 	*@param null
@@ -131,11 +118,64 @@ class UploadClass {
 	public function setFiletype()
 	{
 		//set the value of the file type
-		$this->file_type =  pathinfo($this->target_file,PATHINFO_EXTENSION);
+		$this->file_type =  pathinfo($_FILES[$this->file_name]['name'],PATHINFO_EXTENSION);
 
 		return $this;
 
 	}
+
+	/**
+	*This method sets a unique target file name
+	*
+	*@param null
+	*@return \Object $this instance
+	*/
+	public function setTargetfilename()
+	{
+		//set the value of target file name
+		$this->target_file_name = sprintf('%s.%s',sha1_file($_FILES[$this->file_name]['tmp_name']),$this->file_type);
+
+		return $this;
+
+	}
+
+	/**
+	*This method sets the target file name
+	*
+	*@param null
+	*@return \Object $this instance
+	*/
+	public function setTargetfile()
+	{
+		//set the upload_path_relative
+		$this->upload_path_relative = $this->upload_path . $this->target_file_name;
+
+		//set the full target file path
+		$this->target_file = $this->target_dir . $this->target_file_name;
+
+		return $this;
+
+	}
+
+
+	/**
+	*This method checks if a valid file type was uploaded
+	*@param string $file_type The name of the file type to check
+	*@return \Object $this instance
+	*/
+	public function checkFiletype($file_type)
+	{
+		//check if the type was specified
+		if( null !== $file_type)
+		{
+
+			return $this;
+		}
+
+		else return $this;
+
+	}
+
 
 	/**
 	*This method sets the uploaded filesize

--- a/system/Helpers/Url/Url.php
+++ b/system/Helpers/Url/Url.php
@@ -81,7 +81,7 @@ class Url {
 	 *@throws this method does not throw an error
 	 *
 	 */
-	public static function assets($assetName)
+	public static function assets($assetName = null)
 	{
 		//get the server name from global $_SERVER[] array()
 		$base  = $_SERVER['SERVER_NAME']; 

--- a/system/Helpers/Url/Url.php
+++ b/system/Helpers/Url/Url.php
@@ -42,7 +42,7 @@ class Url {
 	 *@throws this method does not throw an error
 	 *
 	 */
-	public static function base($fileName)
+	public static function base()
 	{
 
 		//get the server name from global $_SERVER[] array()


### PR DESCRIPTION
Initially the printing of back trace error message was limited to the second array element. However, I have since discovered that a more verbose message is essential for troubleshooting errors in chained method calls. I have therefore enabled printing of the whole backtrace as the error message to facilitate identifying the possible line where the caught error was triggered.
