### PR TITLE
Reducing the verbosity of error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 composer.phar
-bin/logs/error.log
-application/
-config/
-
 
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/application/views/subview.glade.php
+++ b/application/views/subview.glade.php
@@ -1,0 +1,14 @@
+        <div class="right-col">
+
+            @if(isset($users) AND count($users) > 0)
+
+                @foreach($users as $user)
+                    <tr>
+                        <td>{{$user['name']}} </td><td>{{$user['email']}} </td><td>{{$user['profile_photo']}} </td>
+                    </tr>
+
+                @endforeach
+
+            @endif
+
+        </div>

--- a/system/Exceptions/BaseExceptionClass.php
+++ b/system/Exceptions/BaseExceptionClass.php
@@ -102,7 +102,7 @@ class BaseExceptionClass extends \Exception implements BaseExceptionInterface  {
 	*/
 	public function getErrorMessage(){
 
-		$backTrace = $this->getTraceAsString(); $appendPrevious = $backTrace;// substr($backTrace, 2, strpos($backTrace, "#2") - 2);
+		$backTrace = $this->getTraceAsString(); $appendPrevious = substr($backTrace, 2, (strpos($backTrace, "#4")) ? strpos($backTrace, "#4") - 2 : 1000);
 
 		//define and return the error message to show
 		$this->errorMessageContent = '<b>' . $this->getMessage() . ' ' . $this->getFile() . '(' . $this->getLine() . ')</b> As seen from ' . $appendPrevious;

--- a/system/Exceptions/Debug/BaseShutdown.php
+++ b/system/Exceptions/Debug/BaseShutdown.php
@@ -136,7 +136,8 @@ function handler( $errNo, $errMsg, $errFile, $errLine ) {
     $rootPath = dirname(dirname(dirname((dirname(__FILE__)))));
 
     $exceptionObject = new Exception;$backTrace = $exceptionObject->getTraceAsString();
-    $appendPrevious = $backTrace;//substr($backTrace, 2, strpos($backTrace, "#4") - 2);
+
+    $appendPrevious = substr($backTrace, 2, (strpos($backTrace, "#4")) ? strpos($backTrace, "#4") - 2 : 1000);
 
     //compose an error message to display
     $showErrorMessage = "<b>$errorType: $errMsg in $errFile on line($errLine)</b> As seen from $appendPrevious";

--- a/system/start.php
+++ b/system/start.php
@@ -8,7 +8,7 @@ return	function() use($config){
 		//check of the routes configuration file exists
 		if ( ! file_exists( __DIR__ . '/../application/routes.php'))
 
-			throw new Exceptions\Routes\RouteException("The defined routes file cannot be found! Please restore if you deleted");
+			throw new Drivers\Routes\RouteException("The defined routes.php file cannot be found! Please restore if you deleted");
 		
 		//get the defined routes
 		$definedRoutes = include __DIR__ . '/../application/routes.php';


### PR DESCRIPTION
The more descriptive the error message is the easier it will be to troubleshoot your application. Initial I let the back trace run riot as it wills, so that you can have the whole screen full of error message string. I bet to this extent it may not be as useful. I have therefore throttled back trace to the fourth calling file or class. So far I see that that is satisfactory - if need there be we will lengthen the messages.
