### PR TITLE
Updated dependency version constraints to use caret operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
 	],
 	"require" : {
 		"php" : ">=7.4.0",
-		"glivers/rackage" : "3.*",
-		"glivers/roline" : "2.*"
+		"glivers/rackage" : "^3.0",
+		"glivers/roline" : "^2.0"
 	},
 	"autoload" : {
 		"psr-4" : {


### PR DESCRIPTION
Changed from wildcard (*) to caret (^) operator for better semantic versioning support:
- glivers/rackage: 3.* → ^3.0
- glivers/roline: 2.* → ^2.0

The caret operator allows automatic updates to compatible versions (e.g., 3.1.x, 3.2.x) while blocking breaking changes (4.x).