### PR TITLE
Added rackage dependency to roline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require" : {
-		"php" : ">=7.4.0",
+		"php" : ">=8.0.0",
 		"glivers/rackage" : "^3.0",
 		"glivers/roline" : "^2.0"
 	},


### PR DESCRIPTION
Roline requires rackage classes (Model, View, Controller) for CLI operations, so the dependency must be explicitly declared.

Added:
- glivers/rackage: ^3.0