### PR TITLE
Updated dependencies to Rackage 2.x and raised PHP requirement to 8.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "687384ccfbfdbac88b92c82b56e9b546",
+    "content-hash": "058381db8b100cd9e179cf43b163f3a3",
     "packages": [
         {
             "name": "glivers/rackage",
-            "version": "v3.1.0",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/glivers/rackage.git",
-                "reference": "2130418e93738c0a92492a64e7b0b097764e8528"
+                "reference": "9f4a5ea7e74134a13a16651b47e929c6cfd9467f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/glivers/rackage/zipball/2130418e93738c0a92492a64e7b0b097764e8528",
-                "reference": "2130418e93738c0a92492a64e7b0b097764e8528",
+                "url": "https://api.github.com/repos/glivers/rackage/zipball/9f4a5ea7e74134a13a16651b47e929c6cfd9467f",
+                "reference": "9f4a5ea7e74134a13a16651b47e929c6cfd9467f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.0"
+                "php": ">=8.0.0"
             },
             "type": "package",
             "autoload": {
@@ -42,9 +42,9 @@
             "description": "This is a collection of all the PHP classes that make Rachie a real MVC framework",
             "support": {
                 "issues": "https://github.com/glivers/rackage/issues",
-                "source": "https://github.com/glivers/rackage/tree/v3.1.0"
+                "source": "https://github.com/glivers/rackage/tree/v2.0.0"
             },
-            "time": "2025-12-01T21:26:56+00:00"
+            "time": "2026-01-20T21:42:47+00:00"
         },
         {
             "name": "glivers/roline",
@@ -52,17 +52,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/glivers/roline.git",
-                "reference": "0742e43d23573d3de1a0629a9474740840cebe74"
+                "reference": "3d2b4cfbb651994adb094dbe9e407474a15d3f29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/glivers/roline/zipball/0742e43d23573d3de1a0629a9474740840cebe74",
-                "reference": "0742e43d23573d3de1a0629a9474740840cebe74",
+                "url": "https://api.github.com/repos/glivers/roline/zipball/3d2b4cfbb651994adb094dbe9e407474a15d3f29",
+                "reference": "3d2b4cfbb651994adb094dbe9e407474a15d3f29",
                 "shasum": ""
             },
             "require": {
-                "glivers/rackage": "3.*",
-                "php": ">=7.4"
+                "glivers/rackage": "^2.0",
+                "php": ">=8.0.0"
             },
             "type": "package",
             "autoload": {
@@ -85,7 +85,7 @@
                 "issues": "https://github.com/glivers/roline/issues",
                 "source": "https://github.com/glivers/roline/tree/v2.0.0"
             },
-            "time": "2025-12-01T22:20:21+00:00"
+            "time": "2026-01-20T21:39:39+00:00"
         }
     ],
     "packages-dev": [],
@@ -95,7 +95,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4.0"
+        "php": ">=8.0.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.2.0"


### PR DESCRIPTION
- Updated Rackage package to v2.0.0 with latest improvements
- Updated Roline package to be compatible with Rackage 2.x
- Raised minimum PHP version requirement from 7.4 to 8.0
- Updated composer lock file with new package references and timestamps

This change aligned the project with the current stable versions of core dependencies and ensured compatibility with modern PHP 8.0+ features.